### PR TITLE
Updated to 1.3.1

### DIFF
--- a/lib/class.contact-details.php
+++ b/lib/class.contact-details.php
@@ -22,8 +22,10 @@ final class BirdBrain_Contact_Details {
 
 		if( $data = get_option( 'contact_details' ) ) {
 			if( $attributes['type'] == 'email_address' ) {
-				return antispambot( $data[$attributes['type']] );
-			} else {
+					$theemail = $data[$attributes['type']];
+					$theemail = antispambot($theemail);
+					return "<a href='mailto:$theemail'>$theemail</a>";
+				} else {
 				return $data[$attributes['type']];
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: contact,details,address,email,fax,global,info,mobile,options,phone
 Requires at least: 2.9
 Tested up to: 3.8.1
-Stable tag: 1.3
+Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ If you have found this plugin useful, consider taking a moment to rate it.
 1. Contact Details page in the WordPress administration area
 
 == Changelog ==
+
+= 1.3.1 =
+* When rendering the Email contact type, surround with mailto anchor tag
 
 = 1.3 =
 * When rendering the Email contact type, run through antispampot() to help prevent spam


### PR DESCRIPTION
Now displays emails as mailto links instead of plaintext. Could maybe be simplified more?
